### PR TITLE
Ensure that jitNewObject for value type is not evaluated inline

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5965,8 +5965,8 @@ TR_J9VMBase::canAllocateInlineClass(TR_OpaqueClassBlock *clazzOffset)
    if (clazz->initializeStatus != 1)
       return false;
 
-   // Can not inline the allocation if the class is an interface or abstract
-   if (clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface))
+   // Can not inline the allocation if the class is an interface, abstract or a value type
+   if (clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))
       return false;
    return true;
    }

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -812,7 +812,7 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
      }
 
    if (isClassInitialized)
-      return ((modifiers & (J9AccAbstract | J9AccInterface ))?false:true);
+      return ((modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))?false:true);
 
    return false;
    }


### PR DESCRIPTION
If the class passed to the `jitNewObject` helper is known to be a value type, have `canAllocateInlineClass` returns false for it.  That prevents the JIT from generating inline code for allocating an instance, including preventing it from being eligible for escape analysis.  That
ensures the helper is called at runtime, allowing it to throw an `InstantiationError`.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>