### PR TITLE
Handle 'Q' prefix

### DIFF
--- a/runtime/compiler/env/J2IThunk.cpp
+++ b/runtime/compiler/env/J2IThunk.cpp
@@ -107,6 +107,7 @@ char TR_J2IThunkTable::terseTypeChar(char *type)
       {
       case '[':
       case 'L':
+      case 'Q':
          return TR::Compiler->target.is64Bit()? 'L' : 'I';
       case 'Z':
       case 'B':

--- a/runtime/compiler/env/J2IThunk.hpp
+++ b/runtime/compiler/env/J2IThunk.hpp
@@ -72,7 +72,9 @@ class TR_J2IThunkTable
          case 'J': return TC_LONG;
          case 'F': return TC_FLOAT;
          case 'D': return TC_DOUBLE;
-         case 'L': return TC_REFERENCE;
+         case 'L': 
+         case 'Q':
+            return TC_REFERENCE;
          default:
             TR_ASSERT(0, "Unknown type char '%c'", typeChar);
             return -1;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2460,7 +2460,10 @@ TR_J9VMBase::getClassSignature_DEPRECATED(TR_OpaqueClassBlock * clazz, int32_t &
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      sig[i++] = 'L';
+      if (isValueTypeClass(myClass))
+         sig[i++] = 'Q';
+      else
+         sig[i++] = 'L';
    memcpy(sig+i, name, len);
    i += len;
    if (* name != '[')
@@ -2488,8 +2491,10 @@ TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock * clazz, TR_Memory * trMemory
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      sig[i++] = 'L';
-   memcpy(sig+i, name, len);
+      if (isValueTypeClass(myClass))
+         sig[i++] = 'Q';
+      else
+         sig[i++] = 'L';
    i += len;
    if (* name != '[')
       sig[i++] = ';';
@@ -4812,6 +4817,7 @@ TR_J9VMBase::lookupMethodHandleThunkArchetype(uintptrj_t methodHandle)
       {
       case '[':
       case 'L':
+      case 'Q':
          // The thunkable signature might return some other class, but archetypes
          // returning a reference are always declared to return Object.
          //
@@ -7007,7 +7013,7 @@ TR_J9VM::getClassFromSignature(const char * sig, int32_t sigLength, J9ConstantPo
    J9Class * j9class = NULL;
    TR_OpaqueClassBlock * returnValue = NULL;
 
-   // For a non-array class type, strip off the first 'L' and last ';' of the
+   // For a non-array class type, strip off the first 'L' or 'Q' and last ';' of the
    // signature
    //
    if ((*sig == 'L' || *sig == 'Q') && sigLength > 2)

--- a/runtime/compiler/env/j9fieldsInfo.cpp
+++ b/runtime/compiler/env/j9fieldsInfo.cpp
@@ -36,7 +36,7 @@
 
 static int isReferenceSignature(char *signature)
 {
-     return ( (signature[0] == 'L' )  || (signature[0] == '[') );
+     return ( (signature[0] == 'L' )  || (signature[0] == '[') || (signature[0] == 'Q'));
 }
 
 int TR_VMField::isReference()

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7216,9 +7216,9 @@ TR_ResolvedJ9Method::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
          }
 
       // Walk to the end of the class name, if this is a class name
-      if (*end == 'L')
+      if (*end == 'L' || *end == 'Q')
          {
-         // Assume the form is L<classname>; where <classname> is
+         // Assume the form is L<classname> or Q<classname>; where <classname> is
          // at least 1 char and therefore skip the first 2 chars
          end += 2;
          end = (char *)memchr(end, ';', sigEnd - end);
@@ -7397,14 +7397,14 @@ TR_J9MethodParameterIterator::TR_J9MethodParameterIterator(TR_J9MethodBase &j9Me
 
 TR::DataType TR_J9MethodParameterIterator::getDataType()
    {
-   if (*_sig == 'L' || *_sig == '[')
+   if (*_sig == 'L' || *_sig == '[' || *_sig == 'Q')
       {
       _nextIncrBy = 0;
       while (_sig[_nextIncrBy] == '[')
     {
     ++_nextIncrBy;
     }
-      if (_sig[_nextIncrBy] != 'L')
+   if (_sig[_nextIncrBy] != 'L' && _sig[_nextIncrBy] != 'Q')
     {
     // Primitive array
     ++_nextIncrBy;
@@ -7461,7 +7461,7 @@ TR::DataType TR_J9MethodParameterIterator::getDataType()
 TR_OpaqueClassBlock * TR_J9MethodParameterIterator::getOpaqueClass()
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(_comp.fe());
-   TR_ASSERT(*_sig == '[' || *_sig == 'L', "Asked for class of incorrect Java parameter.");
+   TR_ASSERT(*_sig == '[' || *_sig == 'L' || *_sig == 'Q', "Asked for class of incorrect Java parameter.");
    if (_nextIncrBy == 0) getDataType();
    return _resolvedMethod == NULL ? NULL :
       fej9->getClassFromSignature(_sig, _nextIncrBy, _resolvedMethod);
@@ -7480,7 +7480,7 @@ bool TR_J9MethodParameterIterator::isArray()
 
 bool TR_J9MethodParameterIterator::isClass()
    {
-   return (*_sig == 'L');
+   return (*_sig == 'L' || *_sig == 'Q');
    }
 
 bool TR_J9MethodParameterIterator::atEnd()
@@ -7530,6 +7530,7 @@ static TR::DataType typeFromSig(char sig)
       {
       case 'L':
       case '[':
+      case 'Q':
          return TR::Address;
       case 'I':
       case 'Z':
@@ -7744,6 +7745,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                {
                case 'L':
                case '[':
+               case 'Q':
                   sourceName = "object";
                   sourceType = "Ljava/lang/Object;";
                   break;
@@ -7755,6 +7757,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                {
                case 'L':
                case '[':
+               case 'Q':
                   targetName = "object";
                   targetType = "Ljava/lang/Object;";
                   break;
@@ -7789,7 +7792,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
             // Address conversions need a downcast after the call
             //
-            if (targetType[0] == 'L')
+            if (targetType[0] == 'L' || targetType[0] == 'Q')
                {
                uintptrj_t methodHandle;
                uintptrj_t sourceArguments;
@@ -7956,6 +7959,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                break;
             case 'L':
             case '[':
+            case 'Q':
                callOp = TR::acalli;
                break;
             case 'V':
@@ -8092,6 +8096,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                      {
                      case 'L':
                      case '[':
+                     case 'Q':
                         sprintf(extraName, "extra_L");
                         extraSignature = artificialSignature(stackAlloc, "(L" JSR292_ArgumentMoverHandle ";I)Ljava/lang/Object;");
                         break;
@@ -8175,6 +8180,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
                      {
                      case 'L':
                      case '[':
+                     case 'Q':
                         sprintf(extraName, "extra_L");
                         extraSignature = artificialSignature(stackAlloc, "(L" JSR292_ArgumentMoverHandle ";I)Ljava/lang/Object;");
                         break;

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -71,7 +71,7 @@ inline char *nextSignatureArgument(char *currentArgument)
    char *result = currentArgument;
    while (*result == '[')
       result++;
-   if (*result == 'L')
+   if (*result == 'L' || *result == 'Q')
       while (*result != ';')
          result++;
    return result+1;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5204,7 +5204,7 @@ TR_PrexArgInfo* TR_PrexArgInfo::buildPrexArgInfoForMethodSymbol(TR::ResolvedMeth
       int32_t len = 0;
       const char *sig = p->getTypeSignature(len);
 
-      if (*sig == 'L')
+      if (*sig == 'L' || *sig == 'Q')
          {
          TR_OpaqueClassBlock *clazz = tracer->fe()->getClassFromSignature(sig, len, feMethod);
          if (clazz)

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -88,7 +88,7 @@ class NeedsPeekingHeuristic
             int32_t len;
             const char *sig = p->getTypeSignature(len);
             if (i >= argInfo->getNumArgs() ||            //not enough slots in argInfo
-               *sig != 'L' ||                            //primitive arg
+               (*sig != 'L' && *sig != 'Q') ||           //primitive arg
                !argInfo->get(i) ||                       //no arg at the i-th slot
                !argInfo->get(i)->getClass()         //no classInfo at the i-th slot
                )

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1507,7 +1507,7 @@ J9::ValuePropagation::innerConstrainAcall(TR::Node *node)
    if (sig == NULL)  // helper
        return node;
 
-   TR_ASSERT(sig[0] == 'L' || sig[0] == '[', "Ref call return type is not a class");
+   TR_ASSERT(sig[0] == 'L' || sig[0] == '[' || sig[0] == 'Q', "Ref call return type is not a class");
 
    TR::MethodSymbol *symbol = node->getSymbol()->castToMethodSymbol();
    TR_ResolvedMethod *owningMethod = symRef->getOwningMethod(comp());

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -1473,6 +1473,7 @@ static void printMethodHandleArgs(j9object_t methodHandle, void **stack, J9VMThr
                   break;
                case 'L':
                case '[':
+               case 'Q':
                   TR_VerboseLog::writeLine(vlogTag, "%p     arg " POINTER_PRINTF_FORMAT " %.*s", vmThread, (void*)(*(intptrj_t*)stack), nextArg-curArg, curArg);
                   stack -= 1;
                   break;

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -60,7 +60,7 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize::hashCode(char *sig, uint32_t sigLen)
    bool skipFirstAndLastChars = false;
    if (sigLen > 0)
       {
-      if ((sig[0] == 'L') && (sig[sigLen-1] == ';'))
+      if ((sig[0] == 'L' || sig[0] == 'Q') && (sig[sigLen-1] == ';'))
          skipFirstAndLastChars = true;
       }
 

--- a/runtime/compiler/x/runtime/X86RelocationTarget.cpp
+++ b/runtime/compiler/x/runtime/X86RelocationTarget.cpp
@@ -121,6 +121,7 @@ j9ThunkInvokeExactHelperFromTerseSignature(UDATA signatureLength, char *signatur
       case '[':
          /* intentional fall-through */
       case 'L':
+      case 'Q':
          helper = TR_icallVMprJavaSendInvokeExactL;
          break;
       default:


### PR DESCRIPTION
Many places need proper handling for 'Q' prefix. In some places 
it can be handled in the same way as 'L', whereas in some other 
places, how to handle 'Q' needs to be further considered or 
determined if the situation change (e.g. if 'Q' ends up being passed 
by value).

Signed-off-by: Yiling Han <Yiling.Han@ibm.com>