### PR TITLE
Add query methods for value type classes

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6541,6 +6541,18 @@ TR_J9VMBase::isInterfaceClass(TR_OpaqueClassBlock * clazzPointer)
    }
 
 bool
+TR_J9VMBase::isValueTypeClass(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccValueType) ? true : false;
+   }
+
+bool
+TR_J9VMBase::hasUnflattenedFlattenableFields(TR_OpaqueClassBlock * clazzPointer)
+   {
+   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9ClassContainsUnflattenedFlattenables) ? true : false;
+   }
+
+bool
 TR_J9VMBase::isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *method)
    {
    int32_t modifiersForClass = 0;

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -268,6 +268,8 @@ public:
    virtual bool isAbstractClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isCloneable(TR_OpaqueClassBlock *);
    virtual bool isInterfaceClass(TR_OpaqueClassBlock * clazzPointer);
+   virtual bool isValueTypeClass(TR_OpaqueClassBlock * clazzPointer);
+   virtual bool hasUnflattenedFlattenableFields(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *method);
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *);


### PR DESCRIPTION
Define methods on TR_J9VMBase that check whether a `TR_OpaqueClassBlock` is a value type - `isValueTypeClass` - or contains fields that are value types - `hasUnflattenedFlattenableFields`.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>