### PR TITLE
Implment monitor enter/exit for valuetypes

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -132,14 +132,17 @@ inline void generateLoadJ9Class(TR::Node* node, TR::Register* j9class, TR::Regis
       switch (opValue)
          {
          case TR::checkcastAndNULLCHK:
+         case TR::monent:
+         case TR::monexit:
             needsNULLCHK = true;
             break;
          case TR::icall: // TR_checkAssignable
             return; // j9class register already holds j9class
+         case TR::checkcast:
+         case TR::instanceof:
+            break;
          default:
-            TR_ASSERT(opValue == TR::checkcast ||
-                      opValue == TR::instanceof,
-                     "Unexpected opCode for generateLoadJ9Class %s.", node->getOpCode().getName());
+            TR_ASSERT(false, "Unexpected opCode for generateLoadJ9Class %s.", node->getOpCode().getName());
             break;
          }
       }
@@ -1868,7 +1871,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(
             {
             needExplicitCheck = false;
             TR::MemoryReference *memRef = NULL;
-            if (TR::Compiler->om.compressedReferenceShift() > 0 
+            if (TR::Compiler->om.compressedReferenceShift() > 0
                 && firstChild->getType() == TR::Address
                 && firstChild->getOpCode().hasSymbolReference()
                 && firstChild->getSymbol()->isCollectedReference())
@@ -4508,6 +4511,31 @@ void J9::X86::TreeEvaluator::transactionalMemoryJITMonitorEntry(TR::Node        
       cg->stopUsingRegister(counterReg);
    }
 
+TR_YesNoMaybe static isMonitorValueType(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   J9Class * monitorClass = (J9Class *) cg->getMonClass(node);
+   return monitorClass == NULL? TR_maybe: (J9_IS_J9CLASS_VALUETYPE(monitorClass) ? TR_yes: TR_no);
+   }
+
+void
+J9::X86::TreeEvaluator::monitorEnterOrExitForValueTypeClass(
+      TR::Node *node,
+      TR::LabelSymbol *snippetLabel,
+      TR::CodeGenerator *cg)
+   {
+   if (isMonitorValueType(node, cg) != TR_maybe)
+      return;
+   TR::Register *objectReg = cg->evaluate(node->getFirstChild());
+   auto j9classReg = cg->allocateRegister();
+   generateLoadJ9Class(node, j9classReg, objectReg, cg);
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
+   auto classFlagsMR = generateX86MemoryReference(j9classReg, (uintptrj_t)(fej9->getOffsetOfClassFlags()), cg);
+   static_assert((uint32_t) J9ClassIsValueType < USHRT_MAX);
+   //test [j9classReg.classFlags], J9ClassIsValueType
+   generateMemImmInstruction(TEST2MemImm2, node, classFlagsMR, J9ClassIsValueType, cg);
+   generateLabelInstruction(JNE4, node, snippetLabel, cg);
+   }
+
 TR::Register *
 J9::X86::TreeEvaluator::VMmonentEvaluator(
       TR::Node *node,
@@ -4518,20 +4546,22 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    // appropriate excepting instruction we must make sure to reset the
    // excepting instruction since our children may have set it.
    //
+   TR::Compilation *comp = cg->comp();
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
    static const char *noInline = feGetEnv("TR_NoInlineMonitor");
-   static int32_t monEntCount = 0;
    static const char *firstMonEnt = feGetEnv("TR_FirstMonEnt");
-   static const char *doCmpFirst = feGetEnv("TR_AddCMPBeforeCMPXCHG");
+   static int32_t monEntCount = 0;
    bool reservingLock = false;
    bool normalLockPreservingReservation = false;
    bool dummyMethodMonitor = false;
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-   TR::Compilation *comp = cg->comp();
+
+   static const char *doCmpFirst = feGetEnv("TR_AddCMPBeforeCMPXCHG");
 
    int lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
    if (comp->getOption(TR_MimicInterpreterFrameShape) ||
        (comp->getOption(TR_FullSpeedDebug) && node->isSyncMethodMonitor()) ||
        noInline ||
+       TR::Compiler->om.areValueTypesEnabled() && isMonitorValueType(node, cg) == TR_yes ||
        comp->getOption(TR_DisableInlineMonEnt) ||
        (firstMonEnt && (*firstMonEnt-'0') > monEntCount++))
       {
@@ -4596,6 +4626,8 @@ J9::X86::TreeEvaluator::VMmonentEvaluator(
    TR::SymbolReference *originalNodeSymRef = NULL;
 
    TR::Node *helperCallNode = node;
+   if (TR::Compiler->om.areValueTypesEnabled())
+      monitorEnterOrExitForValueTypeClass(node, snippetLabel, cg);
    if (comp->getOption(TR_ReservingLocks))
       {
       // About to change the node's symref... store the original.
@@ -5124,8 +5156,10 @@ void J9::X86::TreeEvaluator::generateValueTracingCode(
    generateMemRegInstruction(SMemReg(), node, generateX86MemoryReference(vmThreadReg, vmThreadCursor, cg), scratchReg, cg);
    }
 
-TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node,
-                                                     TR::CodeGenerator *cg)
+TR::Register
+*J9::X86::TreeEvaluator::VMmonexitEvaluator(
+      TR::Node          *node,
+      TR::CodeGenerator *cg)
    {
    // If there is a NULLCHK above this node it will be expecting us to set
    // up the excepting instruction.  If we are not going to inline an
@@ -5135,16 +5169,17 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
    static const char *noInline = feGetEnv("TR_NoInlineMonitor");
-   static int32_t monExitCount = 0;
    static const char *firstMonExit = feGetEnv("TR_FirstMonExit");
+   static int32_t monExitCount = 0;
    bool reservingLock = false;
    bool normalLockPreservingReservation = false;
    bool dummyMethodMonitor = false;
    bool gen64BitInstr = cg->comp()->target().is64Bit() && !fej9->generateCompressedLockWord();
-
    int lwOffset = fej9->getByteOffsetToLockword((TR_OpaqueClassBlock *) cg->getMonClass(node));
+
    if ((comp->getOption(TR_MimicInterpreterFrameShape) /*&& !comp->getOption(TR_EnableLiveMonitorMetadata)*/) ||
        noInline ||
+       isMonitorValueType(node, cg) == TR_yes ||
        comp->getOption(TR_DisableInlineMonExit) ||
        (firstMonExit && (*firstMonExit-'0') > monExitCount++))
       {
@@ -5192,7 +5227,10 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
 
    TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *fallThru   = generateLabelSymbol(cg);
-
+   // Create the monitor exit snippet
+   TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
+   if (TR::Compiler->om.areValueTypesEnabled())
+       monitorEnterOrExitForValueTypeClass(node, snippetLabel, cg);
 #if !defined(J9VM_OPT_REAL_TIME_LOCKING_SUPPORT)
    // Now that the object reference has been generated, see if this is the end
    // of a small synchronized block.
@@ -5245,7 +5283,6 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
    TR::LabelSymbol *fallThruFromMonitorLookupCacheLabel = generateLabelSymbol(cg);
 
 #if defined(J9VM_OPT_REAL_TIME_LOCKING_SUPPORT)
-   TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *decCountLabel = generateLabelSymbol(cg);
 
    unlockedReg = cg->allocateRegister();
@@ -5342,10 +5379,6 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node          *node
       1, TR::DebugCounter::Cheap);
 
 #else
-
-   // Create the monitor exit snippet
-   //
-   TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
 
    if (lwOffset <= 0)
       {
@@ -12663,7 +12696,7 @@ TR::Register *
 J9::X86::TreeEvaluator::generateConcurrentScavengeSequence(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register* object = TR::TreeEvaluator::performHeapLoadWithReadBarrier(node, cg);
-   
+
    if (!node->getSymbolReference()->isUnresolved() &&
        (node->getSymbolReference()->getSymbol()->getKind() == TR::Symbol::IsShadow) &&
        (node->getSymbolReference()->getCPIndex() >= 0) &&
@@ -12712,7 +12745,7 @@ J9::X86::TreeEvaluator::irdbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       }
 
-   // Note: For indirect rdbar nodes, the first child (sideEffectNode) is also used by the 
+   // Note: For indirect rdbar nodes, the first child (sideEffectNode) is also used by the
    // load evaluator. The load evaluator will also evaluate+decrement it. In order to avoid double
    // decrementing the node we skip doing it here and let the load evaluator do it.
    return resultReg;
@@ -12780,7 +12813,7 @@ J9::X86::TreeEvaluator::ardbariEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       node->setRegister(resultReg);
       }
 
-   // Note: For indirect rdbar nodes, the first child (sideEffectNode) is also used by the 
+   // Note: For indirect rdbar nodes, the first child (sideEffectNode) is also used by the
    // load evaluator. The load evaluator will also evaluate+decrement it. In order to avoid double
    // decrementing the node we skip doing it here and let the load evaluator do it.
    return resultReg;
@@ -12800,7 +12833,7 @@ TR::Register *J9::X86::TreeEvaluator::fwrtbarEvaluator(TR::Node *node, TR::CodeG
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);
@@ -12821,7 +12854,7 @@ TR::Register *J9::X86::TreeEvaluator::fwrtbariEvaluator(TR::Node *node, TR::Code
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);
@@ -12843,7 +12876,7 @@ TR::Register *J9::X86::i386::TreeEvaluator::dwrtbarEvaluator(TR::Node *node, TR:
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);
@@ -12864,7 +12897,7 @@ TR::Register *J9::X86::i386::TreeEvaluator::dwrtbariEvaluator(TR::Node *node, TR
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);
@@ -12887,7 +12920,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::dwrtbarEvaluator(TR::Node *node, TR
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);
@@ -12908,7 +12941,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::dwrtbariEvaluator(TR::Node *node, T
       TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectRegister, valueReg);
       }
 
-   // Note: The reference count for valueReg's node is not decremented here because the 
+   // Note: The reference count for valueReg's node is not decremented here because the
    // store evaluator also uses it and so it will evaluate+decrement it. Thus we must skip decrementing here
    // to avoid double decrementing.
    cg->decReferenceCount(sideEffectNode);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -90,6 +90,18 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *checkcastinstanceofEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static void asyncGCMapCheckPatching(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *snippetLabel);
    static void inlineRecursiveMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *startLabel, TR::LabelSymbol *snippetLabel, TR::LabelSymbol *JITMonitorEnterSnippetLabel, TR::Register *objectReg, int lwoffset, TR::LabelSymbol *snippetRestartLabel, bool reservingLock);
+
+   /*
+   * \brief Generates the sequence to handle the cases where the monitor object is value type
+   *
+   *  Call the VM helper if it's detected at runtime that the monitor object is value type.
+   *  The VM helper throws appropriate IllegalMonitorStateException for us.
+   *
+   * \notes
+   *    This method only handles the cases where, at compile time, it's unknown whether the
+   *    object is reference type or value type.
+   */
+   static void monitorEnterOrExitForValueTypeClass(TR::Node *node, TR::LabelSymbol *snippetLabel, TR::CodeGenerator *cg);
    static void transactionalMemoryJITMonitorEntry(TR::Node *node, TR::CodeGenerator *cg, TR::LabelSymbol *startLabel, TR::LabelSymbol *snippetLabel, TR::LabelSymbol *JITMonitorEnterSnippetLabel, TR::Register *objectReg, int lwoffset);
    static void generateValueTracingCode(TR::Node *node, TR::Register *vmThreadReg, TR::Register *scratchReg, TR::Register *valueRegHigh, TR::Register *valueRegLow, TR::CodeGenerator *cg);
    static void generateValueTracingCode(TR::Node *node, TR::Register *vmThreadReg, TR::Register *scratchReg, TR::Register *valueReg, TR::CodeGenerator *cg);


### PR DESCRIPTION
Note that the VM helper for monitor enter/exit is expected to throw
IllegalMonitorStateException for value type object but it does not
currently. We are waiting for the changes in VM heplers to make this
code fully work.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>