### PR TITLE
Check for J9ClassContainsUnflattenedFlattenables in classFlags

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5978,8 +5978,10 @@ TR_J9VMBase::canAllocateInlineClass(TR_OpaqueClassBlock *clazzOffset)
    if (clazz->initializeStatus != 1)
       return false;
 
-   // Can not inline the allocation if the class is an interface, abstract or a value type
-   if (clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))
+   // Can not inline the allocation if the class is an interface, abstract or identityless
+   // (a value type) or if it is a class with identityless fields
+   if ((clazz->romClass->modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))
+       || (clazz->classFlags & J9ClassContainsUnflattenedFlattenables))
       return false;
    return true;
    }
@@ -6562,7 +6564,7 @@ TR_J9VMBase::isValueTypeClass(TR_OpaqueClassBlock * clazzPointer)
 bool
 TR_J9VMBase::hasUnflattenedFlattenableFields(TR_OpaqueClassBlock * clazzPointer)
    {
-   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9ClassContainsUnflattenedFlattenables) ? true : false;
+   return (getClassFlagsValue(clazzPointer) & J9ClassContainsUnflattenedFlattenables) ? true : false;
    }
 
 bool

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -876,6 +876,7 @@ bool
 TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
    {
    uint32_t modifiers = 0;
+   uintptr_t classFlags = 0;
    bool isClassInitialized = false;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_INITIALIZED, (void *)&isClassInitialized, JITServerHelpers::CLASSINFO_ROMCLASS_MODIFIERS, (void *)&modifiers);
@@ -894,10 +895,13 @@ TR_J9ServerVM::canAllocateInlineClass(TR_OpaqueClassBlock *clazz)
            it->second._classInitialized = isClassInitialized;
            }
         }
+
+        classFlags = TR_J9ServerVM::getClassFlagsValue(clazz);
      }
 
    if (isClassInitialized)
-      return ((modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType))?false:true);
+      return ((modifiers & (J9AccAbstract | J9AccInterface | J9AccValueType)
+              || (classFlags & J9ClassContainsUnflattenedFlattenables)) ? false : true);
 
    return false;
    }


### PR DESCRIPTION
Code was checking for the `J9ClassContainsUnflattenedFlattenables` flag in the class's `modifiers` field, but that flag is actually in `classFlags`.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>