### PR TITLE
Rename UnresolvedValueTypeFailure to UnsupportedValueTypeOperation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11036,9 +11036,9 @@ TR::CompilationInfoPerThreadBase::processException(
       {
       _methodBeingCompiled->_compErrCode = compilationILGenFailure;
       }
-   catch (const TR::UnresolvedValueTypeFailure &e)
+   catch (const TR::UnsupportedValueTypeOperation &e)
       {
-      _methodBeingCompiled->_compErrCode = compilationILGenUnresolvedValueTypeFailure;
+      _methodBeingCompiled->_compErrCode = compilationILGenUnsupportedValueTypeOpFailure;
       }
    /* IL Gen Exceptions End */
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -209,7 +209,7 @@ char *compilationErrorNames[]={
    "compilationSymbolValidationManagerFailure", //50
    "compilationAOTNoSupportForAOTFailure", //51
    "compilationAOTValidateTMFailure", //52
-   "compilationILGenUnresolvedValueTypeFailure", //53
+   "compilationILGenUnsupportedValueTypeOpFailure", //53
 #if defined(J9VM_OPT_JITSERVER)
    "compilationStreamFailure", //54
    "compilationStreamLostMessage", // 55

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -76,7 +76,7 @@ typedef enum {
    compilationSymbolValidationManagerFailure       = 50,
    compilationAOTNoSupportForAOTFailure            = 51,
    compilationAOTValidateTMFailure                 = 52,
-   compilationILGenUnresolvedValueTypeFailure      = 53,
+   compilationILGenUnsupportedValueTypeOpFailure   = 53,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
    compilationStreamFailure                        = compilationFirstJITServerFailure,

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -6065,7 +6065,7 @@ TR_J9ByteCodeIlGenerator::genWithField(uint16_t fieldCpIndex)
                bcIndex,
                comp()->signature()));
          }
-      comp()->failCompilation<TR::UnresolvedValueTypeFailure>("Unresolved class encountered for withfieldbytecode instruction");
+      comp()->failCompilation<TR::UnsupportedValueTypeOperation>("Unresolved class encountered for withfieldbytecode instruction");
       }
 
    bool isStore = false;
@@ -6089,7 +6089,7 @@ TR_J9ByteCodeIlGenerator::genWithField(uint16_t fieldCpIndex)
                bcIndex,
                comp()->signature()));
          }
-      comp()->failCompilation<TR::UnresolvedValueTypeFailure>("Unresolved field encountered for withfield bytecode instruction");
+      comp()->failCompilation<TR::UnsupportedValueTypeOperation>("Unresolved field encountered for withfield bytecode instruction");
       }
 
    TR::Node *newFieldValue = pop();
@@ -6158,7 +6158,7 @@ TR_J9ByteCodeIlGenerator::genDefaultValue(TR_OpaqueClassBlock *valueTypeClass)
                comp()->signature()));
          }
 
-      comp()->failCompilation<TR::UnresolvedValueTypeFailure>("Unresolved class encountered for defaultvalue bytecode instruction");
+      comp()->failCompilation<TR::UnsupportedValueTypeOperation>("Unresolved class encountered for defaultvalue bytecode instruction");
       }
 
    TR::SymbolReference *valueClassSymRef = symRefTab()->findOrCreateClassSymbol(_methodSymbol, 0, valueTypeClass);
@@ -6193,7 +6193,7 @@ TR_J9ByteCodeIlGenerator::genDefaultValue(TR_OpaqueClassBlock *valueTypeClass)
                comp()->signature()));
          }
 
-      comp()->failCompilation<TR::UnresolvedValueTypeFailure>("Unresolved class encountered for defaultvalue bytecode instruction");
+      comp()->failCompilation<TR::UnsupportedValueTypeOperation>("Unresolved class encountered for defaultvalue bytecode instruction");
       }
    else
       {


### PR DESCRIPTION
The name of the exception thrown during IL generation has changed in OMR to make it less tightly tied to its actual use in OpenJ9.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>