### PR TITLE
Add query method for class with unflattened value type fields

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -627,3 +627,9 @@ J9::ClassEnv::isValueTypeClass(TR_OpaqueClassBlock *clazz)
    J9Class *j9class = reinterpret_cast<J9Class*>(clazz);
    return J9_IS_J9CLASS_VALUETYPE(j9class);
    }
+
+bool
+J9::ClassEnv::hasUnflattenedValueTypeField(TR_OpaqueClassBlock *clazz)
+   {
+   return (classFlagsValue(clazz) & J9ClassContainsUnflattenedFlattenables) != 0;
+   }

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -89,6 +89,20 @@ public:
    bool isAbstractClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isInterfaceClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer);
    bool isValueTypeClass(TR_OpaqueClassBlock *);
+
+   /**
+    * \brief
+    *    Checks whether the specified class has fields that are value types that have not been expanded
+    *    (flattened) into their own components.
+    *
+    * \param clazz
+    *    The class that is to be checked for unflattened value type fields
+    *
+    * \return
+    *    `true` if the specified class has unexpanded value type fields;
+    *    `false` otherwise
+    */
+   bool hasUnflattenedValueTypeField(TR_OpaqueClassBlock *clazz);
    bool isEnumClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazzPointer, TR_ResolvedMethod *method);
    bool isPrimitiveClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);
    bool isAnonymousClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz);


### PR DESCRIPTION
Classes with value type fields might have those fields flattened (thatis, expanded into their components).  `hasUnflattenedValueTypeFields` checks whether a class has any such fields that have not been flattened.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>