### PR TITLE
Switch to value type query methods from ClassEnv

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -685,7 +685,7 @@ J9::Compilation::canAllocateInline(TR::Node* node, TR_OpaqueClassBlock* &classIn
       // Arrays of value type classes must have all their elements initialized with the
       // default value of the component type.  For now, prevent inline allocation of them.
       //
-      if (areValueTypesEnabled && self()->fej9()->isValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
+      if (areValueTypesEnabled && TR::Compiler->cls.isValueTypeClass(reinterpret_cast<TR_OpaqueClassBlock*>(clazz)))
          {
          return -1;
          }


### PR DESCRIPTION
The `isValueTypeClass` and `hasUnflattenedFlattenableFields` methods have
moved from `J9VM` to `ClassEnv`.  Switch to using the new method definitions.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>