### PR TITLE
Move value type query methods to ClassEnv

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2470,7 +2470,7 @@ TR_J9VMBase::getClassSignature_DEPRECATED(TR_OpaqueClassBlock * clazz, int32_t &
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      if (isValueTypeClass(myClass))
+      if (TR::Compiler->cls.isValueTypeClass(myClass))
          sig[i++] = 'Q';
       else
          sig[i++] = 'L';
@@ -2501,7 +2501,7 @@ TR_J9VMBase::getClassSignature(TR_OpaqueClassBlock * clazz, TR_Memory * trMemory
    for (i = 0; i < numDims; i++)
       sig[i] = '[';
    if (* name != '[')
-      if (isValueTypeClass(myClass))
+      if (TR::Compiler->cls.isValueTypeClass(myClass))
          sig[i++] = 'Q';
       else
          sig[i++] = 'L';
@@ -6554,18 +6554,6 @@ bool
 TR_J9VMBase::isInterfaceClass(TR_OpaqueClassBlock * clazzPointer)
    {
    return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccInterface) ? true : false;
-   }
-
-bool
-TR_J9VMBase::isValueTypeClass(TR_OpaqueClassBlock * clazzPointer)
-   {
-   return (TR::Compiler->cls.romClassOf(clazzPointer)->modifiers & J9AccValueType) ? true : false;
-   }
-
-bool
-TR_J9VMBase::hasUnflattenedFlattenableFields(TR_OpaqueClassBlock * clazzPointer)
-   {
-   return (getClassFlagsValue(clazzPointer) & J9ClassContainsUnflattenedFlattenables) ? true : false;
    }
 
 bool

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -268,8 +268,6 @@ public:
    virtual bool isAbstractClass(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isCloneable(TR_OpaqueClassBlock *);
    virtual bool isInterfaceClass(TR_OpaqueClassBlock * clazzPointer);
-   virtual bool isValueTypeClass(TR_OpaqueClassBlock * clazzPointer);
-   virtual bool hasUnflattenedFlattenableFields(TR_OpaqueClassBlock * clazzPointer);
    virtual bool isEnumClass(TR_OpaqueClassBlock * clazzPointer, TR_ResolvedMethod *method);
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual bool isPrimitiveArray(TR_OpaqueClassBlock *);


### PR DESCRIPTION
The `isValueTypeClass` and `hasUnflattenedFlattenableFields` methods are moving from `J9VM` to `ClassEnv`.  Drop the old method definitions.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>