### PR TITLE
Check for array elements with value type fields

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -756,7 +756,7 @@ done:
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		if (J9_IS_J9CLASS_FLATTENED(arrayClass)) {
 			instance = objectAllocate->inlineAllocateIndexableValueTypeObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);
-		} else
+		} else if (J9_ARE_NO_BITS_SET(arrayClass->classFlags, J9ClassContainsUnflattenedFlattenables))
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 		{
 			instance = objectAllocate->inlineAllocateIndexableObject(currentThread, arrayClass, size, initializeSlots, memoryBarrier, sizeCheck);


### PR DESCRIPTION
Check whether array elements have value type fields that have not been flattened in deciding whether inline allocation can be used to allocate the array.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>